### PR TITLE
Standardize redshift-dependent templates and fix Vnorm for sps_parameters

### DIFF
--- a/eazy/tests/test_photoz.py
+++ b/eazy/tests/test_photoz.py
@@ -191,10 +191,18 @@ def test_sps_parameters():
     """
     global ez
     
+    import astropy.units as u
+    
     ### Run all photo-zs
     ez.fit_catalog(fitter='nnls')
         
     ### SPS parameters
+    
+    # Parameters normalized by V band
+    sps = ez.sps_parameters(template_fnu_units=None, simple=True)
+    fnu = template_fnu_units=(1*u.solLum / u.Hz)
+    sps = ez.sps_parameters(template_fnu_units=fnu, simple=True)
+    
     # Full RF-colors with filter weighting
     zout, hdu = ez.standard_output(zbest=None, rf_pad_width=0.5, rf_max_err=2, 
                                    prior=True, beta_prior=True, simple=False,


### PR DESCRIPTION
This fix standardizes the behavior for both ways of computing the SPS parameters with and without ``template_fnu_units`` in terms of redshift-dependent templates.  

Also, it fixes a rather serious bug in the way the SPS parameters are calculated from the template coefficients.  The SPS parameters for the templates in a given template file are tabulated in an accompanying file ``param['TEMPLATES_FILE']+'.fits'``, which at a minimum should have columns like ``Lv``, ``mass``, and ``sfr`` representing the V-band luminosity (``L_sun``), stellar mass (``M_sun``) and (100 Myr) SFR of the template (``M_sun / yr``).  The templates themselves can either be provided with explicit flux density units, e.g., ``L_sun / Hz`` for FSPS templates, or with arbitrary units.  The earlier behavior of ``PhotoZ.sps_parameters`` assumed this latter case with arbitrary units and derived the parameters by normalizing both the fit coefficients and the parameters to the rest-V band, summing the product of the normalized parameters and coefficients and then multiplying this sum by the empirical rest-frame V-band luminosity derived from the photometry.

The previous behavior was as follows:

```python
# coeffs_norm are coeffs_best scaling coefficients normalized at rest-V and with unity sum
Lv_norm = coeffs_norm.dot(param['Lv'])
mass_norm = coeffs_norm.dot(param['mass'])

# Lv is derived V-band luminosity  in L_sun
mass_final = mass_norm / Lv_norm * Lv
```

which is incorrect because the parameters in this way must also be normalized by the V-band luminosity of the templates.  The correct behavior should be 

```python
# coeffs_norm are coeffs_best scaling coefficients normalized at rest-V and with unity sum
mass_norm = coeffs_norm.dot(param['mass']/param['Lv'])

# Lv is derived rest-frame V-band luminosity in L_sun
mass_final = mass_norm * Lv
```

or perhaps more explicitly

```python
# coeffs_norm are coeffs_best scaling coefficients normalized at rest-V and with unity sum
Lv_norm = coeffs_norm.dot(param['Lv']/param['Lv'])  # = 1
mass_norm = coeffs_norm.dot(param['mass'] / param['Lv'])

# Lv is derived V-band luminosity  in L_sun
mass_final = mass_norm / Lv_norm * Lv = mass_norm * Lv
```

The newer default method assumes explicit flux density units on the templates and derives the parameters by doing the unit conversion based on the absolute (f_ν) flux scale of the catalog indicated in the ``PRIOR_ABZP`` parameter and `dL(z)` for a specified cosmology.  With the changes here, both methods now agree for a given set of templates modulo the slight difference in ``Lv`` derived from the interpolated rest-frame flux in the unit-free case and the implicit ``Lv`` derived from the tabulated values in the cgs-units case.

**Note**: this PR also removes the ``LIR_wave`` keyword from ``sps_parameters`` and returns ``LIR`` from the tabulated values as for the other parameters.