### PR TITLE
Fix catalog reader for csv files

### DIFF
--- a/eazy/photoz.py
+++ b/eazy/photoz.py
@@ -623,7 +623,7 @@ class PhotoZ(object):
             self.cat = self.param['CATALOG_FILE']
         elif 'fits' in self.param['CATALOG_FILE'].lower():
             self.cat = Table.read(self.param['CATALOG_FILE'], format='fits')
-        elif self.param['CATALOG_FILE'].lower().endswith('csv'):
+        elif self.param['CATALOG_FILE'].lower().endswith('.csv'):
             self.cat = Table.read(self.param['CATALOG_FILE'], format='csv')        
         else:
             self.cat = Table.read(self.param['CATALOG_FILE'], 


### PR DESCRIPTION
The PR updates the catalog reader such that the "csv" format is used only if the catalog file ends with the ".csv" extension.  Currently ".ecsv" ([ECSV Format](https://docs.astropy.org/en/stable/io/ascii/ecsv.html)) catalog files cannot be read (an error is raised) because they require the "ascii.ecsv" format instead of "csv".