### PR TITLE
"Sonora" brown dwarf templates in eazy format

### DIFF
--- a/eazy/templates.py
+++ b/eazy/templates.py
@@ -1398,7 +1398,8 @@ def load_phoenix_stars(logg_list=PHOENIX_LOGG, teff_list=PHOENIX_TEFF, zmet_list
 
 def load_sonora_stars():
     """
-    Load Sonora brown dwarf models
+    Load Sonora brown dwarf models: Marley et al. (2018, 
+    https://zenodo.org/record/1309035)
     """
     import glob
     


### PR DESCRIPTION
Solar-metallicity "Sonora" templates derived from https://zenodo.org/record/1309035 (Marley et al. 2018):
[sonora_m0.0.tgz](https://github.com/gbrammer/eazy-py/files/11654099/sonora_m0.0.tgz)

```python
"""
Sonora
https://zenodo.org/record/1309035
Sonora Cholla
https://zenodo.org/record/4450269
Bobcat
https://zenodo.org/record/5063476
"""

import glob
import os
import numpy as np
import astropy.units as u
from grizli import utils

import eazy

files = glob.glob('spectra/sp_*0')
files.sort()

R = 1000
wR = utils.log_zgrid([1000, 35.e4], 1./R)

for file in files:
    print(file)
    _x = np.loadtxt(file, skiprows=2, unpack=True)
    
    wave = _x[0][::-1]*u.micron
    fnu = _x[1][::-1]*u.erg/u.second/u.cm**2/u.Hz
    flam = fnu * 3.e18 * u.Angstrom/u.second / (wave)**2
    flam = flam.to(u.erg/u.second/u.cm**2/u.Angstrom)
    
    t = eazy.templates.Template(arrays=(wave, flam))
    tr = t.resample(wR, in_place=False)
    
    tab = tr.to_table()
    tab['flux'].format = '.4e'
    
    teff, g = np.cast[int](file.split('t')[2].split('nc')[0].split('g'))
    logg = np.log10(g*100)
    met = file.split('_')[-1]
    
    tab.meta['origfile'] = os.path.basename(file)
    tab.meta['logg'] = logg
    tab.meta['teff'] = teff
    
    out = f'sonora/sonora_t{teff:04d}_g{logg:3.1f}_{met}'
    tab.write(out+'.fits', overwrite=True)
   ```