### PR TITLE
Update installation of dust packages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,14 +3,14 @@
 
 .. image:: https://badge.fury.io/py/eazy.svg
     :target: https://badge.fury.io/py/eazy
-        
+
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.5012705.svg
    :target: https://doi.org/10.5281/zenodo.5012705
-   
+
 
 eazy-py: Pythonic photometric redshift tools based on EAZY
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-   
+
 Under heavy construction....
 
 Documentation will be here: https://eazy-py.readthedocs.io/, though it's essentially just the module API for now.
@@ -26,6 +26,9 @@ Installation instructions
 .. code:: bash
 
     pip install eazy
+
+    # Forked dependencies that are not yet released on PyPI
+    pip install git+https://github.com/gbrammer/dust_attenuation.git
 
 Demo
 ~~~~

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,7 @@ install_requires =
     tqdm
     h5py
     astro-sedpy>=0.3
-    dust_attenuation @ git+https://github.com/karllark/dust_attenuation#egg=dust_attenuation
-    dust_extinction @ git+https://github.com/gbrammer/dust_extinction.git#egg=dust_extinction
+    dust_extinction
 packages = find:
 include_package_data = True
 


### PR DESCRIPTION
This PR modified the setup.cfg to install `dust_extinction` from PyPI.  `dust_attenuation` has not been released on PyPI and must be installed separately:

`"ERROR: Packages installed from PyPI cannot depend on packages which are not also hosted on PyPI."`

This separate installation of `dust_attenuation` is noted in the installation instructions.