### PR TITLE
LOWZ brown dwarf templates

### DIFF
--- a/eazy/photoz.py
+++ b/eazy/photoz.py
@@ -5225,7 +5225,7 @@ class PhotoZ(object):
         self.set_sys_err(positive=True, in_place=True)
 
 
-    def fit_phoenix_stars(self, wave_lim=[3000, 4.e4], apply_extcorr=False, sys_err=None, stars=None):
+    def fit_phoenix_stars(self, filter_mask=None, wave_lim=[3000, 4.e4], apply_extcorr=False, sys_err=None, stars=None, sonora=True, just_dwarfs=False, lowz_kwargs={}):
         """
         Fit grid of Phoenix stars
         
@@ -5234,13 +5234,25 @@ class PhotoZ(object):
         
         """
         if stars is None:
-            stars = templates_module.load_phoenix_stars(add_carbon_star=False)
+            if just_dwarfs:
+                if sonora:
+                    sonora_templates = templates_module.load_sonora_stars()
+                else:
+                    sonora_templates = []
+                    
+                _ = templates_module.load_LOWZ_templates(**lowz_kwargs)
+                lowz_csv, lowz_templates = _
+                stars = sonora_templates + lowz_templates
+                
+            else:
+                stars = templates_module.load_phoenix_stars(add_carbon_star=False,
+                                                            sonora_dwarfs=sonora)
             
         self.star_templates = stars
         tflux = [t.integrate_filter(self.filters, z=0, include_igm=False)
                      for t in self.star_templates]
         
-        templ_params = [[float(s[1:]) for s in t.name.split('_')[1:]] 
+        templ_params = [[float(s[1:]) for s in t.name.split('_')[1:4]] 
                          for t in stars]
         self.star_teff = np.array(templ_params)[:,0]
         self.star_logg = np.array(templ_params)[:,1]
@@ -5258,14 +5270,17 @@ class PhotoZ(object):
             _wht = 1/(self.efnu**2+(self.param.params['SYS_ERR']*self.fnu)**2)
         else:
             _wht = 1/(self.efnu**2+(sys_err*self.fnu)**2)
-            
-        _wht[(~self.ok_data) | (self.efnu <= 0)] = 0
         
+        _wht /= self.zp**2
+        _wht[(~self.ok_data) | (self.efnu <= 0)] = 0
+                    
         clip_filter = (self.pivot < wave_lim[0]) | (self.pivot > wave_lim[1])
-         
+        if filter_mask is not None:
+             clip_filter &= filter_mask
+             
         _wht[:, clip_filter] = 0
             
-        _num = np.dot(self.fnu*_wht, self.star_flux)
+        _num = np.dot(self.fnu*self.zp*_wht, self.star_flux)
         _den= np.dot(1*_wht, self.star_flux**2)
         _den[_den == 0] = 0
         self.star_tnorm = _num/_den
@@ -5274,12 +5289,14 @@ class PhotoZ(object):
         self.star_chi2 = np.zeros(self.star_tnorm.shape, dtype=np.float32)
         for i in range(self.NSTAR):
             _m = self.star_tnorm[:,i:i+1]*self.star_flux[:,i]
-            self.star_chi2[:,i] = ((self.fnu - _m)**2*_wht).sum(axis=1)
+            self.star_chi2[:,i] = ((self.fnu*self.zp - _m)**2*_wht).sum(axis=1)
         
         self.star_min_ix = np.argmin(self.star_chi2, axis=1)
         
         self.star_min_chi2 = self.star_chi2.min(axis=1)
         self.star_min_chinu = self.star_min_chi2 / (self.nusefilt - 1)
+        
+        self.star_gal_chi2 = ((self.fnu*self.zp - self.fmodel)**2*_wht).sum(axis=1)
 
 
     def _redshift_pairs(self, rix=None):


### PR DESCRIPTION
Options to LOWZ brown dwarf templates [(Meisner et al. 2021)](https://ui.adsabs.harvard.edu/abs/2021ApJ...915..120M/).

-  Fetch the templates from https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/SJRXUO
```python
eazy.templates.download_LOWZ_templates()
```

- Load a grid of the LOWZ models as `eazy.templates.Template` objects
```python
eazy.templates.load_LOWZ_templates(metallicity=[-2.5, 1.0],
                                   logg=[3.5, 5.25],
                                   teff=[500, 1600],
                                   ctoo=[0.1, 0.55, 0.85],
                                   logkzz=[-1.,2.,10.])
```

-  Fit them to the catalog photometry as was done with the PHOENIX and Sonora templates before
```python
eazy.photoz.PhotoZ.fit_phoenix_stars(..., just_dwarfs=True)
```