### PR TITLE
Fix calculation of pivot wavelength in FilterDefinition class

### DIFF
--- a/eazy/filters.py
+++ b/eazy/filters.py
@@ -184,8 +184,8 @@ class FilterDefinition:
         """
         integrator = np.trapz
         
-        num = integrator(self.wave, self.wave*self.throughput)
-        den = integrator(self.wave, self.throughput/self.wave)
+        num = integrator(self.wave*self.throughput, self.wave)
+        den = integrator(self.throughput/self.wave, self.wave)
         pivot = np.sqrt(num/den)
         return pivot
     


### PR DESCRIPTION
Hello, I noticed an error in the calculation of the pivot wavelength. The first and second arguments for `np.trapz` need to be swapped to fix this.