### PR TITLE
Renormalize templates before fitting them to the photometry

### DIFF
--- a/eazy/data/zphot.param.default
+++ b/eazy/data/zphot.param.default
@@ -23,6 +23,10 @@ SYS_ERR              0.01               # Systematic flux error (% of flux)
 APPLY_IGM            y                  # Apply Madau 1995 IGM absorption
 IGM_SCALE_TAU        1.0                # Scale factor times Inoue14 IGM tau
 
+FITTER               nnls               # Template fit mode
+RENORM_TEMPLATES     y                  # Renormalize templates before fitting
+HESS_THRESHOLD       1                  # Threshold for removing degenerate templates using the Hessian matrix
+
 SCALE_2175_BUMP      0.00               # Scaling of 2175A bump.  Values 0.13 (0.27) absorb ~10 (20) % at peak.
 TEMPLATE_SMOOTH       0.0               # Velocity smoothing (km/s) for templates, < 0 for no smoothing
 RESAMPLE_WAVE        None

--- a/eazy/photoz.py
+++ b/eazy/photoz.py
@@ -1226,8 +1226,13 @@ class PhotoZ(object):
             fig.tight_layout(pad=0.1)
             
         """
-        prior_raw = np.loadtxt(prior_file)
-        prior_header = open(prior_file).readline()
+        if prior_file.startswith('templates') & (not os.path.exists('templates')):
+            _file = os.path.join(utils.DATA_PATH, prior_file)
+        else:
+            _file = prior_file
+        
+        prior_raw = np.loadtxt(_file)
+        prior_header = open(_file).readline()
         
         prior_mags = np.asarray(prior_header.split()[2:],dtype=float)
         NZ = len(zgrid)
@@ -1505,7 +1510,7 @@ class PhotoZ(object):
         self.fit_catalog(*args, **kwargs)
 
 
-    def fit_catalog(self, idx=None, n_proc=4, verbose=True, get_best_fit=True, prior=False, beta_prior=False, fitter='nnls', **kwargs):
+    def fit_catalog(self, idx=None, n_proc=4, verbose=True, get_best_fit=True, prior=False, beta_prior=False, **kwargs):
         """
         This is the main function for fitting redshifts for a full catalog
         and is parallelized by fitting each redshift grid step separately.
@@ -1538,10 +1543,6 @@ class PhotoZ(object):
         beta_prior : bool
             Apply UV slope beta priorr
         
-        fitter : str
-            Least-squares method for template fits.  See
-            `~eazy.photoz.template_lsq`.        
-            
         Returns
         -------
         Updates various attributes, like `chi2_fit`, `fit_coeffs`.
@@ -1572,21 +1573,27 @@ class PhotoZ(object):
         
         missing = self.fnu[idx_fit,:] < self.param['NOT_OBS_THRESHOLD']
         efnu_corr[missing] = self.param['NOT_OBS_THRESHOLD'] - 9.
-        
+
+        fitter = self.param['FITTER']
+        renorm_t = self.param['RENORM_TEMPLATES'] in utils.TRUE_VALUES
+
         t0 = time.time()
         if (n_proc == 0) | (mp.cpu_count() == 1):
             # Serial by redshift
             np_check = 1
             for iz, z in tqdm(enumerate(self.zgrid)):
-                _res = fit_by_redshift(iz,
-                                       self.zgrid[iz],
-                                       self.tempfilt(self.zgrid[iz]),
-                                       fnu_corr,
-                                       efnu_corr,
-                                       self.TEF(z),
-                                       self.zp, 
-                                       self.param.params['VERBOSITY'], 
-                                       fitter)
+                _res = fit_by_redshift(
+                    iz,
+                    self.zgrid[iz],
+                    self.tempfilt(self.zgrid[iz]),
+                    fnu_corr,
+                    efnu_corr,
+                    self.TEF(z),
+                    self.zp, 
+                    self.param.params['VERBOSITY'], 
+                    fitter,
+                    renorm_t
+                )
                 
                 self.chi2_fit[idx_fit,iz] = _res[1]
                 self.fit_coeffs[idx_fit,iz,:] = _res[2]
@@ -1599,19 +1606,24 @@ class PhotoZ(object):
                 np_check = np.minimum(mp.cpu_count(), n_proc)
         
             pool = mp.Pool(processes=np_check)
-        
-            jobs = [pool.apply_async(fit_by_redshift,
-                                      (iz,
-                                       z,
-                                       self.tempfilt(self.zgrid[iz]),
-                                       fnu_corr,
-                                       efnu_corr,
-                                       self.TEF(z),
-                                       self.zp,
-                                       self.param.params['VERBOSITY'],
-                                       fitter)
-                                      ) 
-                       for iz, z in enumerate(self.zgrid)]
+            
+            jobs = [
+                pool.apply_async(
+                    fit_by_redshift,
+                    (iz,
+                     z,
+                     self.tempfilt(self.zgrid[iz]),
+                     fnu_corr,
+                     efnu_corr,
+                     self.TEF(z),
+                     self.zp,
+                     self.param.params['VERBOSITY'],
+                     fitter,
+                     renorm_t
+                    )
+                ) 
+                for iz, z in enumerate(self.zgrid)
+            ]
 
             pool.close()
         
@@ -1636,13 +1648,16 @@ class PhotoZ(object):
             print(msg.format(t1-t0, np_check, len(idx_fit)))
 
 
-    def _fit_at_redshift(self, iobj, z=None, fitter='nnls'):
+    def _fit_at_redshift(self, iobj, z=None, **kwargs):
         """
         Fit template coefficeints at a single redshift
         
         .. note :: Implemented but not used
     
         """
+        fitter = self.param['FITTER']
+        renorm_t = self.param['RENORM_TEMPLATES'] in utils.TRUE_VALUES
+        
         fnu_i = np.squeeze(self.fnu[iobj, :])*self.ext_redden*self.zp
         efnu_i = np.squeeze(self.efnu[iobj,:])*self.ext_redden*self.zp
         ok_band = (fnu_i/self.zp > self.param['NOT_OBS_THRESHOLD']) 
@@ -1652,25 +1667,35 @@ class PhotoZ(object):
         tef_i = self.TEF(z)
         
         A = np.squeeze(self.tempfilt(z))
-        chi2_i, coeffs_i, fmodel, draws = template_lsq(fnu_i, efnu_i, A, 
-                                                   tef_i, self.zp, 
-                                                   0, fitter)
+        chi2_i, coeffs_i, fmodel, draws = template_lsq(
+            fnu_i,
+            efnu_i,
+            A,
+            tef_i,
+            self.zp,
+            0,
+            fitter,
+            renorm_t
+        )
         
         return chi2_i, coeffs_i, fmodel
 
 
-    def _fit_on_zgrid(self, iobj, fitter='nnls'):
+    def _fit_on_zgrid(self, iobj, **kwargs):
         """
         Fit a single object on the redshift grid
         
         .. note :: Implemented but not used
         
         """
+        fitter = self.param['FITTER']
+        renorm_t = self.param['RENORM_TEMPLATES'] in utils.TRUE_VALUES
+        
         chi2 = np.zeros(self.NZ, dtype=self.ARRAY_DTYPE)
         coeffs = np.zeros((self.NZ, self.NTEMP), dtype=self.ARRAY_DTYPE)
     
         for iz, z in enumerate(self.zgrid):
-            _ = self.fit_at_redshift(iobj, z=z, fitter=fitter)
+            _ = self.fit_at_redshift(iobj, z=z, fitter=fitter, renorm_t=renorm_t)
             chi2[iz,:], coeffs[iz] = _[:2]
         
         return iobj, chi2, coeffs
@@ -1712,7 +1737,7 @@ class PhotoZ(object):
         self.ZML_WITH_BETA_PRIOR = beta_prior
 
 
-    def fit_at_zbest(self, zbest=None, prior=False, beta_prior=False, get_err=False, clip_wavelength=1100, fitter='nnls', selection=None,  n_proc=0, par_skip=10000, recompute_zml=True, **kwargs):
+    def fit_at_zbest(self, zbest=None, prior=False, beta_prior=False, get_err=False, clip_wavelength=1100, selection=None,  n_proc=0, par_skip=10000, recompute_zml=True, **kwargs):
         """
         Recompute the fit coefficients at the "best" redshift.  
         
@@ -1721,7 +1746,10 @@ class PhotoZ(object):
         
         """
         import multiprocessing as mp
-                
+        
+        fitter = self.param['FITTER']
+        renorm_t = self.param['RENORM_TEMPLATES'] in utils.TRUE_VALUES
+         
         #izbest = np.argmin(self.chi2_fit, axis=1)
         izbest = self.izbest*1
         has_chi2 = (self.chi2_fit != 0).sum(axis=1) > 0 
@@ -1789,17 +1817,20 @@ class PhotoZ(object):
             
         if skip == 1:
             # Serial (pass self at end to update arrays in place)
-            _ = _fit_at_zbest_group(idx, 
-                                fnu_corr[idx,:], 
-                                efnu_corr[idx,:], 
-                                self.zbest[idx], 
-                                self.zp*1, 
-                                get_err, 
-                                fitter, 
-                                self.tempfilt, 
-                                self.TEF,
-                                self.ARRAY_DTYPE, 
-                                None)
+            _ = _fit_at_zbest_group(
+                idx, 
+                fnu_corr[idx,:],
+                efnu_corr[idx,:],
+                self.zbest[idx],
+                self.zp*1,
+                get_err,
+                fitter,
+                renorm_t,
+                self.tempfilt,
+                self.TEF,
+                self.ARRAY_DTYPE,
+                None
+            )
 
             _ix, _coeffs_best, _fmodel, _efmodel, _chi2_best, _cdraws = _
             self.coeffs_best[_ix,:] = _coeffs_best
@@ -1812,15 +1843,25 @@ class PhotoZ(object):
         else:
             # Multiprocessing
             pool = mp.Pool(processes=np_check)
-            jobs = [pool.apply_async(_fit_at_zbest_group, 
-                                          (idx[i::skip], 
-                                           fnu_corr[idx[i::skip],:], 
-                                           efnu_corr[idx[i::skip],:], 
-                                           self.zbest[idx[i::skip]], 
-                                           self.zp*1, get_err, 
-                                           fitter, self.tempfilt, self.TEF,
-                                           self.ARRAY_DTYPE, None)) 
-                        for i in range(skip)]
+            jobs = [
+                pool.apply_async(
+                    _fit_at_zbest_group, (
+                        idx[i::skip], 
+                        fnu_corr[idx[i::skip],:], 
+                        efnu_corr[idx[i::skip],:], 
+                        self.zbest[idx[i::skip]], 
+                        self.zp*1,
+                        get_err, 
+                        fitter,
+                        renorm_t,
+                        self.tempfilt,
+                        self.TEF,
+                        self.ARRAY_DTYPE,
+                        None
+                    )
+                ) 
+                for i in range(skip)
+            ]
 
             pool.close()
             pool.join()
@@ -2434,7 +2475,7 @@ class PhotoZ(object):
         fp.close()
     
     
-    def show_fit(self, id, id_is_idx=False, zshow=None, show_fnu=0, get_spec=False, xlim=[0.3, 9], show_components=False, show_redshift_draws=False, draws_cmap=None, ds9=None, ds9_sky=True, add_label=True, showpz=0.6, logpz=False, zr=None, axes=None, template_color='#1f77b4', figsize=[8,4], ndraws=100, fitter='nnls', show_missing=True, maglim=None, show_prior=False, show_stars=False, delta_chi2_stars=-20, max_stars=3, show_upperlimits=True, snr_thresh=2., with_tef=True, **kwargs):
+    def show_fit(self, id, id_is_idx=False, zshow=None, show_fnu=0, get_spec=False, xlim=[0.3, 9], show_components=False, show_redshift_draws=False, draws_cmap=None, ds9=None, ds9_sky=True, add_label=True, showpz=0.6, logpz=False, zr=None, axes=None, template_color='#1f77b4', figsize=[8,4], ndraws=100, fitter=None, renorm_t=None, show_missing=True, maglim=None, show_prior=False, show_stars=False, delta_chi2_stars=-20, max_stars=3, show_upperlimits=True, snr_thresh=2., with_tef=True, **kwargs):
         """
         Make plot of SED and p(z) of a single object
         
@@ -2501,7 +2542,10 @@ class PhotoZ(object):
         fitter : str
             Least-squares method for template fits.  See
             `~eazy.photoz.template_lsq`.        
-        
+
+        renorm_t : bool
+            Renormalize templates before fitting
+
         show_missing : bool
             Show points for "missing" data
         
@@ -2597,6 +2641,12 @@ class PhotoZ(object):
         
         global IGM_OBJECT
         
+        if fitter is None:
+            fitter = self.param['FITTER']
+
+        if renorm_t is None:
+            renorm_t = self.param['RENORM_TEMPLATES'] in utils.TRUE_VALUES
+        
         if id_is_idx:
             ix = id
         else:
@@ -2647,9 +2697,16 @@ class PhotoZ(object):
         ## Evaluate coeffs at specified redshift
         tef_i = self.TEF(z)
         A = np.squeeze(self.tempfilt(z))
-        chi2_i, coeffs_i, fmodel, draws = template_lsq(fnu_i, efnu_i, A, 
-                                                   tef_i, self.zp, 
-                                                   ndraws, fitter)
+        chi2_i, coeffs_i, fmodel, draws = template_lsq(
+            fnu_i,
+            efnu_i,
+            A,
+            tef_i,
+            self.zp,
+            ndraws,
+            fitter,
+            renorm_t
+        )
         if draws is None:
             efmodel = 0
         else:
@@ -2658,16 +2715,21 @@ class PhotoZ(object):
             
         ## Full SED
         templ = self.templates[0]
-        tempflux = np.zeros((self.NTEMP, templ.wave.shape[0]),
-                            dtype=self.ARRAY_DTYPE)
+        tempflux = np.zeros(
+            (self.NTEMP, templ.wave.shape[0]),
+            dtype=self.ARRAY_DTYPE
+        )
         for i in range(self.NTEMP):
             zargs = {'z':z, 'redshift_type':TEMPLATE_REDSHIFT_TYPE}
-            fnu = self.templates[i].flux_fnu(**zargs)*self.tempfilt.scale[i]
+            fnu = self.templates[i].flux_fnu(**zargs) * self.tempfilt.scale[i]
             try:
                 tempflux[i, :] = fnu
             except:
-                tempflux[i, :] = np.interp(templ.wave,
-                                           self.templates[i].wave, fnu)
+                tempflux[i, :] = np.interp(
+                    templ.wave,
+                    self.templates[i].wave,
+                    fnu
+                )
                 
         templz = templ.wave*(1+z)
 
@@ -2681,7 +2743,7 @@ class PhotoZ(object):
         templf = np.dot(coeffs_i, tempflux)*igmz
                 
         if draws is not None:
-            templf_draws = np.dot(draws, tempflux)*igmz
+            templf_draws = np.dot(draws, tempflux) * igmz
                 
         fnu_factor = 10**(-0.4*(self.param['PRIOR_ABZP']+48.6))
         
@@ -2822,10 +2884,16 @@ class PhotoZ(object):
             
             for zi in zdraws:
                 Az = np.squeeze(self.tempfilt(zi))
-                chi2_zi, coeffs_zi, fmodelz, __ = template_lsq(fnu_i, efnu_i, 
-                                                       Az, 
-                                                       self.TEF(zi), self.zp, 
-                                                       0, fitter)
+                chi2_zi, coeffs_zi, fmodelz, __ = template_lsq(
+                    fnu_i,
+                    efnu_i,
+                    Az,
+                    self.TEF(zi),
+                    self.zp,
+                    0,
+                    fitter,
+                    renorm_t
+                )
                                                        
                 c_i = np.interp(zi, self.zgrid, np.arange(self.NZ)/self.NZ)
                 
@@ -3277,7 +3345,7 @@ class PhotoZ(object):
         return tab
 
 
-    def rest_frame_fluxes(self, f_numbers=DEFAULT_UBVJ_FILTERS, pad_width=0.5, max_err=0.5, ndraws=1000, percentiles=[2.5,16,50,84,97.5], simple=False, verbose=1, fitter='nnls', n_proc=-1, par_skip=10000, **kwargs):
+    def rest_frame_fluxes(self, f_numbers=DEFAULT_UBVJ_FILTERS, pad_width=0.5, max_err=0.5, ndraws=1000, percentiles=[2.5,16,50,84,97.5], simple=False, verbose=1, n_proc=-1, par_skip=10000, **kwargs):
         """
         Rest-frame fluxes, refit by down-weighting bands far away from 
         the desired RF band.
@@ -3343,7 +3411,10 @@ class PhotoZ(object):
         fitter : str
             Least-squares method for template fits.  See
             `~eazy.photoz.template_lsq`.
-                
+        
+        renorm_t : bool
+            Renormalize templates before fitting
+
         n_proc, par_skip : int, int
             Number of processes to use.  If zero, then run in serial mode.  
             Otherwise, will run in parallel threads splitting the catalog into 
@@ -3363,6 +3434,9 @@ class PhotoZ(object):
         """
         import multiprocessing as mp
         import time
+        
+        fitter = self.param['FITTER']
+        renorm_t = self.param['RENORM_TEMPLATES'] in utils.TRUE_VALUES
         
         NREST = len(f_numbers)
         if isinstance(f_numbers[0], int):
@@ -3434,7 +3508,8 @@ class PhotoZ(object):
                                 self.zbest[idx], 
                                 self.zp*1, 
                                 ndraws, 
-                                fitter, 
+                                fitter,
+                                renorm_t,
                                 self.tempfilt,
                                 self.ARRAY_DTYPE, 
                                 rf_tempfilt, 
@@ -3460,24 +3535,30 @@ class PhotoZ(object):
             t0 = time.time()
 
             pool = mp.Pool(processes=np_check)
-            jobs = [pool.apply_async(_fit_rest_group, 
-                                          (idx[i::skip], 
-                                           fnu_corr[idx[i::skip],:], 
-                                           efnu_corr[idx[i::skip],:], 
-                                           izbest[idx[i::skip]], 
-                                           self.zbest[idx[i::skip]], 
-                                           self.zp*1, 
-                                           ndraws, 
-                                           fitter,
-                                           self.tempfilt,
-                                           self.ARRAY_DTYPE, 
-                                           rf_tempfilt,
-                                           percentiles, 
-                                           rf_lc,
-                                           pad_width,
-                                           max_err,
-                                           skip))
-                        for i in range(skip)]
+            jobs = [
+            pool.apply_async(
+                    _fit_rest_group, (
+                        idx[i::skip], 
+                        fnu_corr[idx[i::skip],:], 
+                        efnu_corr[idx[i::skip],:], 
+                        izbest[idx[i::skip]], 
+                        self.zbest[idx[i::skip]], 
+                        self.zp*1, 
+                        ndraws, 
+                        fitter,
+                        renorm_t,
+                        self.tempfilt,
+                        self.ARRAY_DTYPE, 
+                        rf_tempfilt,
+                        percentiles, 
+                        rf_lc,
+                        pad_width,
+                        max_err,
+                        skip
+                    )
+                )
+                for i in range(skip)
+            ]
 
             pool.close()
             #pool.join()
@@ -4574,7 +4655,7 @@ class PhotoZ(object):
         return tab
 
 
-    def standard_output(self, zbest=None, prior=False, beta_prior=False, UBVJ=DEFAULT_UBVJ_FILTERS, extra_rf_filters=DEFAULT_RF_FILTERS, cosmology=None, simple=False, rf_pad_width=0.5, rf_max_err=0.5, save_fits=True, get_err=True, percentile_limits=[2.5, 16, 50, 84, 97.5], fitter='nnls', n_proc=0, clip_wavelength=1100, absmag_filters=[271, 272, 274], run_find_peaks=False, **kwargs):#
+    def standard_output(self, zbest=None, prior=False, beta_prior=False, UBVJ=DEFAULT_UBVJ_FILTERS, extra_rf_filters=DEFAULT_RF_FILTERS, cosmology=None, simple=False, rf_pad_width=0.5, rf_max_err=0.5, save_fits=True, get_err=True, percentile_limits=[2.5, 16, 50, 84, 97.5], n_proc=0, clip_wavelength=1100, absmag_filters=[271, 272, 274], run_find_peaks=False, **kwargs):#
         """
         Full output to ``zout.fits`` file.  
         
@@ -4625,11 +4706,7 @@ class PhotoZ(object):
         
         get_err : bool
             Get parameter percentiles at `percentile_limits`.
-        
-        fitter : 'nnls', 'bounded'
-            Least-squares method for template fits.  See
-            `~eazy.photoz.template_lsq`.
-        
+
         absmag_filters : list
             Optional list of filters to compute absolute (AB) magnitudes
         
@@ -4647,6 +4724,9 @@ class PhotoZ(object):
         import astropy.io.fits as pyfits
         from .version import __version__
         
+        fitter = self.param['FITTER']
+        renorm_t = self.param['RENORM_TEMPLATES'] in utils.TRUE_VALUES
+        
         if self.param['VERBOSITY'] >= 1:
             print('Get best fit coeffs & best redshifts')
                         
@@ -4661,7 +4741,7 @@ class PhotoZ(object):
         # Fit at max-lnp (default if zbest = None) first and record this 
         # information no matter what.          
         self.fit_at_zbest(zbest=None, prior=prior, beta_prior=beta_prior, 
-                      get_err=get_err, fitter=fitter, n_proc=n_proc, 
+                      get_err=get_err, fitter=fitter, renorm_t=renorm_t, n_proc=n_proc, 
                       clip_wavelength=clip_wavelength)
         
         tab['z_ml'] = self.zbest
@@ -4672,7 +4752,8 @@ class PhotoZ(object):
         # z_pdf if zbest is None
         if zbest is not None:
             self.fit_at_zbest(zbest=zbest, prior=prior, beta_prior=beta_prior, 
-                          get_err=get_err, fitter=fitter, n_proc=n_proc, 
+                          get_err=get_err, fitter=fitter, renorm_t=renorm_t,
+                          n_proc=n_proc, 
                           clip_wavelength=clip_wavelength)
                
         try:
@@ -5628,8 +5709,13 @@ class TemplateGrid(object):
         if cosmology is None:
             #from astropy.cosmology import WMAP9 as cosmology
             cosmology = self.cosmology
-            
-        sfh = Table.read(sfh_file)
+        
+        if sfh_file.startswith('templates') & (not os.path.exists('templates')):
+            _file = os.path.join(utils.DATA_PATH, sfh_file)
+        else:
+            _file = sfh_file
+        
+        sfh = Table.read(_file)
         mass_accum = np.cumsum(sfh['SFH'][::-1,:], axis=0)
         mass_accum = (mass_accum / mass_accum[-1,:])[::-1,:]
         t_accum = sfh['time']
@@ -5712,7 +5798,7 @@ def _integrate_tempfilt(itemp, templ, zgrid, RES, f_numbers, add_igm, galactic_e
     return itemp, tempfilt
 
 
-def fit_by_redshift(iz, z, A, fnu_corr, efnu_corr, TEFz, zp, verbose, fitter):
+def fit_by_redshift(iz, z, A, fnu_corr, efnu_corr, TEFz, zp, verbose, fitter, renorm_t):
     """
     Fit all objects in the catalog at a given reshift for parallelization
     
@@ -5743,7 +5829,10 @@ def fit_by_redshift(iz, z, A, fnu_corr, efnu_corr, TEFz, zp, verbose, fitter):
     fitter : str
         Least-squares method for template fits.  See
         `~eazy.photoz.template_lsq`.    
-        
+    
+    renorm_t : bool
+        Renormalize templates before fitting
+    
     Returns
     -------
     iz : int
@@ -5774,13 +5863,22 @@ def fit_by_redshift(iz, z, A, fnu_corr, efnu_corr, TEFz, zp, verbose, fitter):
         if ok_band.sum() < 2:
             continue
         
-        _res = template_lsq(fnu_i, efnu_i, A, TEFz, zp, False, fitter)
+        _res = template_lsq(
+            fnu_i,
+            efnu_i,
+            A,
+            TEFz,
+            zp,
+            False,
+            fitter,
+            renorm_t
+        )
         chi2[iobj], coeffs[iobj], fmodel, draws = _res
             
     return iz, chi2, coeffs
 
 
-def _fit_at_zbest_group(ix, fnu_corr, efnu_corr, zbest, zp, get_err, fitter, tempfilt, TEF, ARRAY_DTYPE, _self):
+def _fit_at_zbest_group(ix, fnu_corr, efnu_corr, zbest, zp, get_err, fitter, renorm_t, tempfilt, TEF, ARRAY_DTYPE, _self):
     """
     Standalone function for fitting individual objects and getting 
     coefficients and random draws
@@ -5825,7 +5923,7 @@ def _fit_at_zbest_group(ix, fnu_corr, efnu_corr, zbest, zp, get_err, fitter, tem
         fnu_i = fnu_corr[iobj, :]
         efnu_i = efnu_corr[iobj,:]
         if get_err:
-            _ = template_lsq(fnu_i, efnu_i, A, TEFz, zp, NDRAWS, fitter)
+            _ = template_lsq(fnu_i, efnu_i, A, TEFz, zp, NDRAWS, fitter, renorm_t)
             chi2, coeffs_best[iobj,:], fmodel[iobj,:], draws = _
             if draws is None:
                 efmodel[iobj,:] = -1
@@ -5836,7 +5934,7 @@ def _fit_at_zbest_group(ix, fnu_corr, efnu_corr, zbest, zp, get_err, fitter, tem
                 efmodel[iobj,:] = efm
                 coeffs_draws[iobj, :, :] = draws
         else:
-            _ = template_lsq(fnu_i, efnu_i, A, TEFz, zp, False, fitter)
+            _ = template_lsq(fnu_i, efnu_i, A, TEFz, zp, False, fitter, renorm_t)
             chi2, coeffs_best[iobj,:], fmodel[iobj,:], draws = _
 
         chi2_best[iobj] = chi2
@@ -5847,7 +5945,7 @@ def _fit_at_zbest_group(ix, fnu_corr, efnu_corr, zbest, zp, get_err, fitter, tem
         return True
 
 
-def _fit_rest_group(ix, fnu_corr, efnu_corr, izbest, zbest, zp, get_err, fitter, tempfilt, ARRAY_DTYPE, rf_tempfilt, percentiles, rf_lc, pad_width, max_err, threads):
+def _fit_rest_group(ix, fnu_corr, efnu_corr, izbest, zbest, zp, get_err, fitter, renorm_t, tempfilt, ARRAY_DTYPE, rf_tempfilt, percentiles, rf_lc, pad_width, max_err, threads):
     """
     Standalone function for fitting rest-frame fluxes for individual objects
     """
@@ -5894,7 +5992,7 @@ def _fit_rest_group(ix, fnu_corr, efnu_corr, izbest, zbest, zp, get_err, fitter,
 
             TEFz = (2/(1+grow/grow.max())-1)*max_err
         
-            _ = template_lsq(fnu_i, efnu_i, A, TEFz, zp, NDRAWS, fitter)
+            _ = template_lsq(fnu_i, efnu_i, A, TEFz, zp, NDRAWS, fitter, renorm_t)
             chi2_i, coeffs_i, fmodel_i, draws = _
             
             if draws is None:
@@ -5910,17 +6008,17 @@ def _fit_rest_group(ix, fnu_corr, efnu_corr, izbest, zbest, zp, get_err, fitter,
 #BOUNDED_DEFAULTS = {'bounds':(1.e3, 1.e18), 'method': 'bvls', 'tol': 1.e-8, 'verbose': 0}
 BOUNDED_DEFAULTS = {'bound_range':[0.05, 20], 'method': 'trf', 'tol': 1.e-8, 'verbose': 0, 'normalize_type':0}
 
-def _fit_obj(fnu_i, efnu_i, A, TEFz, zp, ndraws, fitter):
+def _fit_obj(fnu_i, efnu_i, A, TEFz, zp, ndraws, fitter, renorm_t):
     """
     Wrapper for back-compatibility
     """
     warnings.warn(f'_fit_obj is deprecated, use template_lsq',
                   AstropyUserWarning)
     
-    return template_lsq(fnu_i, efnu_i, A, TEFz, zp, ndraws, fitter)
+    return template_lsq(fnu_i, efnu_i, A, TEFz, zp, ndraws, fitter, renorm_t)
 
 
-def template_lsq(fnu_i, efnu_i, A, TEFz, zp, ndraws, fitter):
+def template_lsq(fnu_i, efnu_i, Ain, TEFz, zp, ndraws, fitter, renorm_t):
     """
     This is the main least-squares function for fitting templates to 
     photometry at a given redshift
@@ -5933,7 +6031,7 @@ def template_lsq(fnu_i, efnu_i, A, TEFz, zp, ndraws, fitter):
     efnu_i : array (NFILT)
         Uncertainties, **including extinction and zeropoint corrections**
     
-    A : array (NTEMP, NFILT)
+    Ain : array (NTEMP, NFILT)
         Design matrix of templates integrated through filter bandpasses at
         a particular redshift, z (not specified but implicit)
     
@@ -5953,6 +6051,9 @@ def template_lsq(fnu_i, efnu_i, A, TEFz, zp, ndraws, fitter):
         non-negative least squares with `scipy.optimize.nnls`, other options
         under development (e.g, 'bounded', 'regularized').
     
+    renorm_t : bool
+        Normalize template arrays
+
     Returns
     -------
     chi2_i : float
@@ -5974,20 +6075,31 @@ def template_lsq(fnu_i, efnu_i, A, TEFz, zp, ndraws, fitter):
     global MIN_VALID_FILTERS
     global BOUNDED_DEFAULTS
     
-    sh = A.shape
+    sh = Ain.shape
 
     # Valid fluxes
     ok_band = (efnu_i/zp > 0) & np.isfinite(fnu_i) & np.isfinite(efnu_i)
     if ok_band.sum() < MIN_VALID_FILTERS:
         coeffs_i = np.zeros(sh[0])
-        fmodel = np.dot(coeffs_i, A)
-        return np.inf, np.zeros(A.shape[0]), fmodel, None
+        fmodel = np.dot(coeffs_i, Ain)
+        return np.inf, np.zeros(Ain.shape[0]), fmodel, None
         
     var = efnu_i**2 + (TEFz*np.maximum(fnu_i, 0.))**2
     rms = np.sqrt(var)
     
     # Nonzero templates
-    ok_temp = (np.sum(A, axis=1) > 0)
+    # ok_temp = (np.sum(A, axis=1) > 0)
+    Anorm = np.linalg.norm(Ain, axis=1, ord=2)
+    ok_temp = Anorm > 0
+    Anorm[~ok_temp] = 1.0
+
+    if not renorm_t:
+        Anorm = Anorm ** 0
+
+    A = (Ain.T / Anorm).T
+    # A = Ain * 1.
+    # A[:,~ok_temp] = 0
+    
     if ok_temp.sum() == 0:
         coeffs_i = np.zeros(sh[0])
         fmodel = np.dot(coeffs_i, A)
@@ -6053,7 +6165,7 @@ def template_lsq(fnu_i, efnu_i, A, TEFz, zp, ndraws, fitter):
             elif '-p' in fitter:
                 # Normalize each template to the *photometry* in a given band
                 band_index = int(fitter.split('-p')[1].split('_')[0])
-                An = A[:,band_index]/fnu_i[band_index]
+                An = A[:,band_index] / fnu_i[band_index]
             elif '-b' in fitter:
                 # Normalize each template to a given band
                 band_index = int(fitter.split('-b')[1].split('_')[0])
@@ -6119,13 +6231,13 @@ def template_lsq(fnu_i, efnu_i, A, TEFz, zp, ndraws, fitter):
         coeffs_i = np.zeros(sh[0])
         
     fmodel = np.dot(coeffs_i, A)
-    chi2_i = ((fnu_i-fmodel)**2/var)[ok_band].sum()
+    chi2_i = ((fnu_i - fmodel)**2 / var)[ok_band].sum()
     
     coeffs_draw = None
     if ndraws > 0:
         if fitter == 'nnls':
             ok_temp = coeffs_i > 0
-            LHSx = Ax[:,ok_temp]*1
+            LHSx = Ax[:,ok_temp]
             An = np.ones(A.shape[0])
             mat = np.dot(LHSx.T, LHSx)
             
@@ -6147,15 +6259,19 @@ def template_lsq(fnu_i, efnu_i, A, TEFz, zp, ndraws, fitter):
         #try:
         if ok_temp.sum() > 0:
             covar = utils.safe_invert(mat)
-            draws = np.random.multivariate_normal((coeffs_i*An)[ok_temp], 
+            draws = np.random.multivariate_normal((coeffs_i * An)[ok_temp], 
                                                   covar, 
                                                   size=ndraws)
-            coeffs_draw[:, ok_temp] = draws/An[ok_temp]
+            coeffs_draw[:, ok_temp] = draws / An[ok_temp]
         else:
             #print('Error getting coeffs draws')
             #coeffs_draw = None
             pass 
-            
+        
+        coeffs_draw /= Anorm
+    
+    coeffs_i /= Anorm
+
     return chi2_i, coeffs_i, fmodel, coeffs_draw
 
 


### PR DESCRIPTION
With this update the template ``A`` matrix (NTEMP columns by NFILT rows) of the templates integrated through the filter bandpasses at a particular redshift is normalized by the Euclidean norm of the columns before fitting them to the photometry, e.g., with ``nnls`` least squares.  The normalization term is put back into the coefficients after the fit.  This can be disabled by setting the new parameter ``RENORM_TEMPLATES = 0`` in ``zphot.param`` or the parameter dictionary.  *This seems to dramatically improve the template fits in fields with relatively sparse filter coverage.*

Also implemented is an option try to reduce the degeneracies between templates at a particular redshift, which is done by calculating the Hessian of the uncertainty-weighted error matrix $H = A_\sigma^T~A_\sigma$, where the columns of $A_\sigma$ are the normalized, uncertainty-weighted template vectors $A_{\sigma,k} = (A_k / \sigma) / || A_k / \sigma ||^2$.

$H$ has dimensions ``NTEMP x NTEMP`` with off-diagonal terms given by the dot products of all of the template photometry vectors.  If the templates were all orthogonal, $H$ would be unit diagonal ($H_{i, j \ne i} = 0$); degenerate templates $i$ and $j$ will have $H_{i,j} > 0$ and perfectly degenerate templates (for a given set of filters at a given redshift) will have $H_{i,j} = 1$.

A new parameter is introduced, ``HESS_THRESHOLD`` that steps through the templates in the order they are provided and removes subsequent templates where $j > i$ and $H_{i,j} > threshold$.  Many templates are **nearly** degenerate, but ``HESS_THRESHOLD = 0.99`` seems to work reasonably well for removing the worst degeneracies.  The thresholding approach is a bit ad hoc, but it's not immediately clear how to implement some other factorization of $A$ that removes the degeneracies but that can still use the non-negativity constraint when using physically-motivated templates.