### PR TITLE
Generalize paths to data files in utils.DATA_PATH

### DIFF
--- a/eazy/__init__.py
+++ b/eazy/__init__.py
@@ -38,7 +38,6 @@ except ImportError:
 #               'to be able to import prospect.')
 #         os.environ['SPS_HOME'] = sps_home
 
-
 def fetch_eazy_photoz():
     """
     If necessary, clone the eazy-photoz repository to get templates and filters

--- a/eazy/filters.py
+++ b/eazy/filters.py
@@ -242,7 +242,7 @@ class FilterDefinition:
 
 
 class FilterFile:
-    def __init__(self, file='FILTER.RES.latest', path='./'):
+    def __init__(self, file='FILTER.RES.latest', path=None):
         """
         Read a EAZY filter file.
         
@@ -271,8 +271,10 @@ class FilterFile:
             
         
         """
-        if path is None:
-            file_path = os.path.join(os.getenv('EAZYCODE'), 'filters', file)
+        if os.path.exists(file):
+            file_path = file
+        elif path is None:
+            file_path = os.path.join(utils.DATA_PATH, 'filters', file)
         else:
             file_path = os.path.join(path, file)
             

--- a/eazy/sps.py
+++ b/eazy/sps.py
@@ -835,6 +835,8 @@ class ExtendedFsps(StellarPopulation):
         """
         Set the far-IR template for reprocessed dust emission
         """
+        if file.startswith('templates') & (not os.path.exists('templates')):
+            file = os.path.join(utils.DATA_PATH, file)
         
         if unset:
             if verbose:

--- a/eazy/templates.py
+++ b/eazy/templates.py
@@ -48,9 +48,15 @@ class TemplateError(object):
 
         """
 
-        self.file = file
+        if file.startswith('templates') & (not os.path.exists('templates')):
+            _file = os.path.join(utils.DATA_PATH, file)
+        else:
+            _file = file
+            
+        self.file = _file
+        
         if arrays is None:
-            self.te_x, self.te_y = np.loadtxt(file, unpack=True)
+            self.te_x, self.te_y = np.loadtxt(self.file, unpack=True)
         else:
             self.te_x, self.te_y = arrays
                    
@@ -353,7 +359,12 @@ def read_templates_file(templates_file=None, as_dict=False, **kwargs):
         List of `eazy.templates.Template` objects (`dict` if ``as_dict``)
         
     """
-    lines = open(templates_file).readlines()
+    if templates_file.startswith('templates') & (not os.path.exists('templates')):
+        _file = os.path.join(utils.DATA_PATH, templates_file)
+    else:
+        _file = templates_file
+
+    lines = open(_file).readlines()
     templates = []
     
     for line in lines:
@@ -366,7 +377,10 @@ def read_templates_file(templates_file=None, as_dict=False, **kwargs):
             to_angstrom = float(lspl[2])
         else:
             to_angstrom = 1.
-            
+        
+        if template_file.startswith('templates') & (not os.path.exists('templates')):
+            template_file = os.path.join(utils.DATA_PATH, template_file)
+        
         templ = Template(file=template_file, to_angstrom=to_angstrom, 
                          **kwargs)
         
@@ -1370,7 +1384,7 @@ def load_phoenix_stars(logg_list=PHOENIX_LOGG, teff_list=PHOENIX_TEFF, zmet_list
     from astropy.table import Table
     import astropy.io.fits as pyfits
     
-    paths = ['/tmp', './templates/', './']
+    paths = ['/tmp', './templates/', './', os.path.join(utils.DATA_PATH, 'templates')]
     hdu = None
     for path in paths:
         templ_path = os.path.join(path, file)
@@ -1411,6 +1425,9 @@ def load_phoenix_stars(logg_list=PHOENIX_LOGG, teff_list=PHOENIX_TEFF, zmet_list
         tstars.append(Template(arrays=arrays, name=label, redfunc=None))
 
     cfile = 'templates/stars/carbon_star.txt'
+    if not os.path.exists('templates'):
+        cfile = os.path.join(utils.DATA_PATH, cfile)
+    
     if add_carbon_star & os.path.exists(cfile):
         sp = Table.read(cfile, format='ascii.commented_header')
         if add_carbon_star > 1:
@@ -1441,7 +1458,7 @@ def load_sonora_stars():
     """
     import glob
     
-    paths = ['/tmp', './templates/', './']
+    paths = ['/tmp', './templates/', './', os.path.join(utils.DATA_PATH, 'templates')]
     found = False
     
     for path in paths:

--- a/eazy/utils.py
+++ b/eazy/utils.py
@@ -15,6 +15,44 @@ FALSE_VALUES = [False, 0, '0', 'False', 'FALSE', 'false', 'n', 'no', 'N', 'No']
 FNU_CGS = u.erg/u.second/u.cm**2/u.Hz
 FLAM_CGS = u.erg/u.second/u.cm**2/u.Angstrom
 
+DATA_PATH = None
+
+def set_data_path(path='$EAZYCODE'):
+    """
+    Make symbolic links to EAZY inputs
+
+    Parameters
+    ----------
+    path : str
+        Full directory path or environment variable pointing to the old eazy
+        C-code repository that provides the template and filter files.
+
+        If `path.startswith('$')` then treat path as an environment variable.
+
+        If you install from the repository that provides the eazy-photozy
+        code as a submodule, then you should be able to run with `path=None`
+        and retrieve the files directly from the repository.  This should
+        also work with the `pip` installation.
+
+        Another safe way to ensure that the necessary files are avialable is
+        to clone the `eazy-photoz` repository and set an environment variable
+        to point to it (e.g, 'EAZYCODE'), which you then pass as the `path`
+        argument.
+
+    """
+    global DATA_PATH
+    if path.startswith('$'):
+        path = os.getenv(path)
+
+    if path is None:
+        # Use the code attached to the repository
+        path = os.path.join(os.path.dirname(__file__), 'data/')
+    
+    DATA_PATH = path
+    return path
+    
+set_data_path()
+
 def bool_param(value, false_values=FALSE_VALUES, true_values=TRUE_VALUES, which='false', check_both=True):
     """
     Flexible booleans


### PR DESCRIPTION
Make finding paths to the templates and filter files easier without symbolic links.

The code will still look for `templates` and `FILTERS.RES.latest` in the working directory, but should fall back to use them directly from the module path if not otherwise found.