### PR TITLE
Add option to fit just a subset of the catalog in ``PhotoZ.fit_phoenix_stars``

### DIFF
--- a/eazy/tests/test_photoz.py
+++ b/eazy/tests/test_photoz.py
@@ -378,8 +378,19 @@ def test_fit_stars():
     Fit phoenix star library for Star/Galaxy separation
     """
     global ez
-    ez.fit_phoenix_stars()
-    assert(np.allclose(ez.star_chi2[0,0], 3191.3662))
+    res = ez.fit_phoenix_stars()
+    assert (np.allclose(ez.star_chi2[0,0], 3191.3662))
+    
+    sub_index = np.array([0,1])
+    sub_bool = np.zeros(ez.NOBJ, dtype=bool)
+    sub_bool[:2] = True
+    
+    for subset in [sub_index, sub_bool]:
+        res = ez.fit_phoenix_stars(subset=subset)
+        assert 'subset' in res
+        assert res['star_min_ix'].shape == (2,)
+        assert res['star_tnorm'].shape == (2, ez.NSTAR)
+        assert (np.allclose(res['star_chi2'][0,0], 3191.3662))
 
 
 def test_photoz_figures():


### PR DESCRIPTION
With this update one can specify ``PhotoZ.fit_phoenix_stars(..., subset=catalog_subset)``, which might be more memory efficient than fitting an entire catalog.  The ``catalog_subset`` argument can be anything that provides a view of the internal catalog attribute arrays like ``fnu_subset = PhotoZ.fnu[catalog_subset,:]``, e.g., a `slice`, a list of integer indices or a bool array with length ``NOBJ``.

Now a full dictionary of the stellar template fit results is always returned, and if ``subset=None`` the attributes with the same names are set to the ``PhotoZ`` object as before, i.e., for the whole catalog.

The entries of the result dictionary (and the corresponding object attributes) are

 - ``star_tnorm`` : (NOBJ, NSTAR) template normalizations
 - ``star_chi2`` : (NOBJ, NSTAR) chi-squared of the star template fits
 - ``star_min_ix`` : (NOBJ) Index of the template list at star_min_chi2
 - ``star_min_chi2`` : (NOBJ) Minimum chi-squared of the template fits
 - ``star_min_chinu``: (NOBJ) ``star_min_chi2 / (nusefilt - 1)``
 - ``star_gal_chi2``: (NOBJ) chi-squared of the best-fitting galaxy model with the same uncertainty weights as the stellar template fit
