### PR TITLE
Checks for inverting singular matrices

### DIFF
--- a/eazy/photoz.py
+++ b/eazy/photoz.py
@@ -6542,9 +6542,14 @@ def template_lsq(fnu_i, efnu_i, Ain, TEFz, zp, ndraws, fitter, renorm_t, hess_th
         #try:
         if ok_temp.sum() > 0:
             covar = utils.safe_invert(mat)
-            draws = np.random.multivariate_normal((coeffs_i * An)[ok_temp], 
-                                                  covar, 
-                                                  size=ndraws)
+            if np.isfinite(covar).sum() != covar.size:
+                draws = np.full((ndraws, ok_temp.sum()), np.nan)
+            else:
+                draws = np.random.multivariate_normal(
+                    (coeffs_i * An)[ok_temp],
+                    covar,
+                    size=ndraws
+                )
             coeffs_draw[:, ok_temp] = draws / An[ok_temp]
         else:
             #print('Error getting coeffs draws')

--- a/eazy/tests/test_utils.py
+++ b/eazy/tests/test_utils.py
@@ -92,6 +92,11 @@ def test_invert():
     ainv = utils.safe_invert(a)
     assert(np.allclose(np.dot(a, ainv), np.eye(2)))
 
+    # Singular matrix returns np.nan inverse without raising exception
+    a = np.ones((2,2))
+    ainv = utils.safe_invert(a)
+    assert np.all(~np.isfinite(utils.safe_invert(a)))
+
 
 def test_query_string():
     """

--- a/eazy/utils.py
+++ b/eazy/utils.py
@@ -369,14 +369,37 @@ def fill_between_steps(x, y, z, ax=None, *args, **kwargs):
     ax.fill_between(xfull[so], yfull[so], zfull[so], *args, **kwargs)
 
 
-def safe_invert(arr):
+def safe_invert(arr, tol=None):
     """
     Version-safe matrix inversion using `numpy.linalg.inv` or `numpy.matrix.I`
+
+    Parameters
+    ----------
+    arr : array-like
+        Square matrix to invert
+
+    tol : float
+        Tolerance parameter for calculating if arr is singular using the rank from
+        ``np.linalg.matrix_rank(arr, tol=tol)``.  If None, use the numpy default
+        derived from the matrix size and machine epsilon.  If ``arr`` is found to be
+        singular (rank < max(arr.shape)), don't try to invert it and just return an
+        array of NaN values.
+
+    Returns
+    -------
+    inv : array-like
+        Inverse of ``arr``
+
     """
+    # Check that matrix is not singular
+    rank = np.linalg.matrix_rank(arr, tol=tol)
+    if rank < np.max(arr.shape):
+        return arr * np.nan
+
     try:
         from numpy.linalg import inv
         _inv = inv(arr)
-    except:
+    except ImportError:
         _inv = np.matrix(arr).I.A
     
     return _inv


### PR DESCRIPTION
Add a check in `eazy.utils.safe_invert` to see if the matrix to be inverted is singular using its rank.

(Fix for https://github.com/gbrammer/eazy-py/issues/58)
