### PR TITLE
Turn some docstrings with math into r-strings to fix syntax warnings

### DIFF
--- a/eazy/igm.py
+++ b/eazy/igm.py
@@ -16,7 +16,7 @@ class Asada24(object):
         add_cgm=True,
         **kwargs,
     ):
-        """
+        r"""
         Compute IGM+CGM transmission from Asada et al. 2024, in prep.
         The IGM model is from Inoue+ (2014).
 
@@ -342,7 +342,7 @@ class Inoue14(object):
     max_fuv_wave = 1300.0
 
     def __init__(self, scale_tau=1.0, **kwargs):
-        """
+        r"""
         IGM absorption from Inoue et al. (2014)
 
         Parameters

--- a/eazy/photoz.py
+++ b/eazy/photoz.py
@@ -952,7 +952,7 @@ class PhotoZ(object):
 
 
     def set_sys_err(self, positive=True, in_place=True):
-        """
+        r"""
         Include systematic error in uncertainties from `param['SYS_ERR']`.
         
         Parameters
@@ -2538,7 +2538,7 @@ class PhotoZ(object):
     
     
     def show_fit(self, id, id_is_idx=False, zshow=None, show_fnu=0, get_spec=False, xlim=[0.3, 9], show_components=False, show_redshift_draws=False, draws_cmap=None, ds9=None, ds9_sky=True, add_label=True, showpz=0.6, logpz=False, zr=None, axes=None, template_color='#1f77b4', figsize=[8,4], ndraws=100, fitter=None, renorm_t=None, hess_threshold=None, show_missing=True, maglim=None, show_prior=False, show_stars=False, delta_chi2_stars=-20, max_stars=3, show_upperlimits=True, snr_thresh=2., with_tef=True, **kwargs):
-        """
+        r"""
         Make plot of SED and p(z) of a single object
         
         Parameters
@@ -4126,7 +4126,7 @@ class PhotoZ(object):
 
 
     def sps_parameters(self, UBVJ=DEFAULT_UBVJ_FILTERS, extra_rf_filters=DEFAULT_RF_FILTERS, cosmology=None, simple=False, rf_pad_width=0.5, rf_max_err=0.5, percentile_limits=[2.5, 16, 50, 84, 97.5], template_fnu_units=(1*u.solLum / u.Hz), vnorm_type=2, n_proc=-1, coeffv_min=0, **kwargs):
-        """
+        r"""
         Rest-frame colors and population parameters at redshift in ``self.zbest`` attribute
         
         Parameters
@@ -6015,7 +6015,7 @@ def _integrate_tempfilt(itemp, templ, zgrid, RES, f_numbers, add_igm, galactic_e
 
 
 def fit_by_redshift(iz, z, A, fnu_corr, efnu_corr, TEFz, zp, verbose, fitter, renorm_t, hess_threshold):
-    """
+    r"""
     Fit all objects in the catalog at a given reshift for parallelization
     
     Parameters

--- a/eazy/sps.py
+++ b/eazy/sps.py
@@ -1777,7 +1777,7 @@ class ExtendedFsps(StellarPopulation):
         target_sfr=None,
         target_lir=None,
     ):
-        """
+        r"""
         Compute a normalization factor to scale input FSPS model flux density
         units of (L_sun / Hz) or (L_sun / \AA) to observed-frame `unit`.
 

--- a/eazy/templates.py
+++ b/eazy/templates.py
@@ -129,7 +129,7 @@ class TemplateError(object):
 
 class Redden(object):
     def __init__(self, model=None, Av=0., **kwargs):
-        """
+        r"""
         Wrapper function for `dust_attenuation` and `dust_extinction` 
         reddening laws
 


### PR DESCRIPTION
Importing some of the modules (I originally had this come up with `import eazy.hdf5`) triggers a handful of `SyntaxWarning`s due to some of the docstrings having not escaping their backslashes. This PR just turns some docstrings into raw strings to avoid that warning.